### PR TITLE
Enable performance insights for RDS instance

### DIFF
--- a/modules/datastore/rds.tf
+++ b/modules/datastore/rds.tf
@@ -138,7 +138,7 @@ resource "aws_db_instance" "this" {
   # enable long tail query logging and export logs to CW so that they are not
   # deleted on expiry.
   parameter_group_name            = aws_db_parameter_group.db_metaflow.name
-  enabled_cloudwatch_logs_exports = "postgresql"
+  enabled_cloudwatch_logs_exports = ["postgresql"]
 
   tags = merge(
     var.standard_tags,

--- a/modules/datastore/rds.tf
+++ b/modules/datastore/rds.tf
@@ -98,7 +98,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 
 resource "aws_db_parameter_group" "db_metaflow" {
   name   = "${var.resource_prefix}${var.db_name}-parameters${var.resource_suffix}"
-  family = "${var.db_engine}${var.db_engine_version}"
+  family = "postgres11"
 
   # long-tail query logging for queries taking > 100 ms
   parameter {


### PR DESCRIPTION
With this PR we enable "RDS Performance Insights" feature for
our metaflow's RDS instance. We limit the retention to 7 days to
stay within the free tier. Additionally we also enable long-tail
query logging and setup CW exporter so that logs are retained
forever.

## Test Plan
Check that terraform is plan is expected,
in particular DB should NOT be destroyed and re-created.