### PR TITLE
Allow randomizing s3 bucket name & update python run time

### DIFF
--- a/modules/datastore/locals.tf
+++ b/modules/datastore/locals.tf
@@ -6,5 +6,15 @@ locals {
   rds_security_group_name = "${var.resource_prefix}rds-security-group${var.resource_suffix}"
 
   # Name of S3 bucket
-  s3_bucket_name = "${var.resource_prefix}s3${var.resource_suffix}"
+  s3_bucket_name_prefix = "${var.resource_prefix}s3${var.resource_suffix}"
+  s3_bucket_name        = var.randomize_s3_name ? "${local.s3_bucket_name_prefix}-${random_string.bucket_suffix.result}" : local.s3_bucket_name_prefix
+}
+
+resource "random_string" "bucket_suffix" {
+  count   = var.randomize_s3_name ? 1 : 0
+  length  = 8
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
 }

--- a/modules/datastore/locals.tf
+++ b/modules/datastore/locals.tf
@@ -7,7 +7,7 @@ locals {
 
   # Name of S3 bucket
   s3_bucket_name_prefix = "${var.resource_prefix}s3${var.resource_suffix}"
-  s3_bucket_name        = var.randomize_s3_name ? "${local.s3_bucket_name_prefix}-${random_string.bucket_suffix.result}" : local.s3_bucket_name_prefix
+  s3_bucket_name        = var.randomize_s3_name ? "${local.s3_bucket_name_prefix}-${random_string.bucket_suffix[0].result}" : local.s3_bucket_name_prefix
 }
 
 resource "random_string" "bucket_suffix" {

--- a/modules/datastore/variables.tf
+++ b/modules/datastore/variables.tf
@@ -51,6 +51,12 @@ variable "resource_suffix" {
   description = "Suffix given to all AWS resources to differentiate between environment and workspace"
 }
 
+variable "randomize_s3_name" {
+  type        = bool
+  default     = false
+  description = "If set to true, adds a 8-character random alphanumeric suffix to s3 bucket name to make it globally unique"
+}
+
 variable "standard_tags" {
   type        = map(string)
   description = "The standard tags to apply to every AWS resource."

--- a/modules/metadata-service/lambda.tf
+++ b/modules/metadata-service/lambda.tf
@@ -115,7 +115,7 @@ data "archive_file" "db_migrate_lambda" {
 resource "aws_lambda_function" "db_migrate_lambda" {
   function_name    = local.db_migrate_lambda_name
   handler          = "index.handler"
-  runtime          = "python3.7"
+  runtime          = "python3.12"
   memory_size      = 128
   timeout          = 900
   description      = "Trigger DB Migration"


### PR DESCRIPTION
Randomizing s3 bucket name is essential because s3 bucket names must be *globally* unique across the entire aws. This means that a bucket name such as `metaflow-s3-dev` is unlikely to qualify, hence we add an optional switch to the module that if set will append a random 8-character string into the bucket name to make it qualify.

The python runtime upgrade is necessary as 3.7 is deprecated by lambda and creating a new lambda fails.