### PR TITLE
Completely deprecate old NLB from the metaflow-metadata-service module

### DIFF
--- a/modules/metadata-service/api-gateway.tf
+++ b/modules/metadata-service/api-gateway.tf
@@ -51,8 +51,8 @@ resource "aws_api_gateway_resource" "db" {
 }
 
 locals {
-  alb_arn      = var.setup_alb && var.point_api_gateway_to_alb ? aws_lb.apigw_nlb[0].arn : aws_lb.this.arn
-  alb_dns_name = var.setup_alb && var.point_api_gateway_to_alb ? aws_lb.apigw_nlb[0].dns_name : aws_lb.this.dns_name
+  alb_arn      = aws_lb.apigw_nlb.arn
+  alb_dns_name = aws_lb.apigw_nlb.dns_name
 }
 
 resource "aws_api_gateway_vpc_link" "this" {

--- a/modules/metadata-service/ec2.tf
+++ b/modules/metadata-service/ec2.tf
@@ -161,7 +161,7 @@ resource "aws_lb" "alb" {
   load_balancer_type = "application"
   idle_timeout       = 180 # 3 minutes
   subnets            = [var.subnet1_id, var.subnet2_id]
-  security_groups    = [aws_security_group.metadata_alb_security_group[0].id]
+  security_groups    = [aws_security_group.metadata_alb_security_group.id]
 
   tags = var.standard_tags
 }
@@ -208,24 +208,24 @@ resource "aws_lb_target_group" "alb_db_migrate" {
 }
 
 resource "aws_lb_listener" "alb_main" {
-  load_balancer_arn = aws_lb.alb[0].arn
+  load_balancer_arn = aws_lb.alb.arn
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.alb_main[0].arn
+    target_group_arn = aws_lb_target_group.alb_main.arn
   }
 }
 
 resource "aws_lb_listener" "alb_db_migrate" {
-  load_balancer_arn = aws_lb.alb[0].arn
+  load_balancer_arn = aws_lb.alb.arn
   port              = "8082"
   protocol          = "HTTP"
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.alb_db_migrate[0].arn
+    target_group_arn = aws_lb_target_group.alb_db_migrate.arn
   }
 }
 
@@ -256,8 +256,8 @@ resource "aws_lb_target_group" "apigw_metadata" {
 }
 
 resource "aws_lb_target_group_attachment" "apigw_metadata" {
-  target_group_arn = aws_lb_target_group.apigw_metadata[0].arn
-  target_id        = aws_lb.alb[0].arn
+  target_group_arn = aws_lb_target_group.apigw_metadata.arn
+  target_id        = aws_lb.alb.arn
 }
 
 resource "aws_lb_target_group" "apigw_db_migrate" {
@@ -279,28 +279,28 @@ resource "aws_lb_target_group" "apigw_db_migrate" {
 }
 
 resource "aws_lb_target_group_attachment" "apigw_db_migrate" {
-  target_group_arn = aws_lb_target_group.apigw_db_migrate[0].arn
-  target_id        = aws_lb.alb[0].arn
+  target_group_arn = aws_lb_target_group.apigw_db_migrate.arn
+  target_id        = aws_lb.alb.arn
 }
 
 resource "aws_lb_listener" "apigw_metadata" {
-  load_balancer_arn = aws_lb.apigw_nlb[0].arn
+  load_balancer_arn = aws_lb.apigw_nlb.arn
   port              = "80"
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.apigw_metadata[0].arn
+    target_group_arn = aws_lb_target_group.apigw_metadata.arn
   }
 }
 
 resource "aws_lb_listener" "apigw_db_migrate" {
-  load_balancer_arn = aws_lb.apigw_nlb[0].arn
+  load_balancer_arn = aws_lb.apigw_nlb.arn
   port              = "8082"
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.apigw_db_migrate[0].arn
+    target_group_arn = aws_lb_target_group.apigw_db_migrate.arn
   }
 }

--- a/modules/metadata-service/ec2.tf
+++ b/modules/metadata-service/ec2.tf
@@ -1,3 +1,58 @@
+moved {
+  from = aws_lb.alb[0]
+  to   = aws_lb.alb
+}
+
+moved {
+  from = aws_lb_target_group.alb_main[0]
+  to   = aws_lb_target_group.alb_main
+}
+
+moved {
+  from = aws_lb_target_group.alb_db_migrate[0]
+  to   = aws_lb_target_group.alb_db_migrate
+}
+
+moved {
+  from = aws_lb_listener.alb_main[0]
+  to   = aws_lb_listener.alb_main
+}
+
+moved {
+  from = aws_lb_listener.alb_db_migrate[0]
+  to   = aws_lb_listener.alb_db_migrate
+}
+
+moved {
+  from = aws_lb.apigw_nlb[0]
+  to   = aws_lb.apigw_nlb
+}
+
+moved {
+  from = aws_lb_target_group.apigw_metadata[0]
+  to   = aws_lb_target_group.apigw_metadata
+}
+
+moved {
+  from = aws_lb_target_group.apigw_db_migrate[0]
+  to   = aws_lb_target_group.apigw_db_migrate
+}
+
+moved {
+  from = aws_lb_listener.apigw_metadata[0]
+  to   = aws_lb_listener.apigw_metadata
+}
+
+moved {
+  from = aws_lb_listener.apigw_db_migrate[0]
+  to   = aws_lb_listener.apigw_db_migrate
+}
+
+moved {
+  from = aws_security_group.metadata_alb_security_group[0]
+  to   = aws_security_group.metadata_alb_security_group
+}
+
 resource "aws_security_group" "metadata_service_security_group" {
   name        = local.metadata_service_security_group_name
   description = "Security Group for Fargate which runs the Metadata Service."
@@ -45,8 +100,6 @@ resource "aws_security_group" "metadata_service_security_group" {
 }
 
 resource "aws_security_group" "metadata_alb_security_group" {
-  count = var.setup_alb ? 1 : 0
-
   name        = local.metadata_alb_security_group_name
   description = "Security Group for ALB which fronts the Metadata Service."
   vpc_id      = var.metaflow_vpc_id
@@ -102,74 +155,7 @@ resource "aws_security_group_rule" "rds_sg_ingress" {
   security_group_id        = var.database_sg_id
 }
 
-resource "aws_lb" "this" {
-  name               = "${var.resource_prefix}nlb${var.resource_suffix}"
-  internal           = true
-  load_balancer_type = "network"
-  subnets            = [var.subnet1_id, var.subnet2_id]
-
-  tags = var.standard_tags
-}
-
-resource "aws_lb_target_group" "this" {
-  name        = "${var.resource_prefix}mdtg${var.resource_suffix}"
-  port        = 8080
-  protocol    = "TCP"
-  target_type = "ip"
-  vpc_id      = var.metaflow_vpc_id
-
-  health_check {
-    protocol            = "TCP"
-    interval            = 10
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-  }
-
-  tags = var.standard_tags
-}
-
-resource "aws_lb_target_group" "db_migrate" {
-  name        = "${var.resource_prefix}dbtg${var.resource_suffix}"
-  port        = 8082
-  protocol    = "TCP"
-  target_type = "ip"
-  vpc_id      = var.metaflow_vpc_id
-
-  health_check {
-    protocol            = "TCP"
-    port                = 8080
-    interval            = 10
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-  }
-
-  tags = var.standard_tags
-}
-
-resource "aws_lb_listener" "this" {
-  load_balancer_arn = aws_lb.this.arn
-  port              = "80"
-  protocol          = "TCP"
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.this.id
-  }
-}
-
-resource "aws_lb_listener" "db_migrate" {
-  load_balancer_arn = aws_lb.this.arn
-  port              = "8082"
-  protocol          = "TCP"
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.db_migrate.id
-  }
-}
-
 resource "aws_lb" "alb" {
-  count              = var.setup_alb ? 1 : 0
   name               = "${var.resource_prefix}metadata-alb${var.resource_suffix}"
   internal           = true
   load_balancer_type = "application"
@@ -181,7 +167,6 @@ resource "aws_lb" "alb" {
 }
 
 resource "aws_lb_target_group" "alb_main" {
-  count                         = var.setup_alb ? 1 : 0
   name                          = "${var.resource_prefix}alb-mdtg${var.resource_suffix}"
   port                          = 8080
   protocol                      = "HTTP"
@@ -203,7 +188,6 @@ resource "aws_lb_target_group" "alb_main" {
 
 
 resource "aws_lb_target_group" "alb_db_migrate" {
-  count       = var.setup_alb ? 1 : 0
   name        = "${var.resource_prefix}alb-dbtg${var.resource_suffix}"
   port        = 8082
   protocol    = "HTTP"
@@ -224,7 +208,6 @@ resource "aws_lb_target_group" "alb_db_migrate" {
 }
 
 resource "aws_lb_listener" "alb_main" {
-  count             = var.setup_alb ? 1 : 0
   load_balancer_arn = aws_lb.alb[0].arn
   port              = "80"
   protocol          = "HTTP"
@@ -236,7 +219,6 @@ resource "aws_lb_listener" "alb_main" {
 }
 
 resource "aws_lb_listener" "alb_db_migrate" {
-  count             = var.setup_alb ? 1 : 0
   load_balancer_arn = aws_lb.alb[0].arn
   port              = "8082"
   protocol          = "HTTP"
@@ -248,7 +230,6 @@ resource "aws_lb_listener" "alb_db_migrate" {
 }
 
 resource "aws_lb" "apigw_nlb" {
-  count              = var.setup_alb && var.point_api_gateway_to_alb ? 1 : 0
   name               = "${var.resource_prefix}apigw-nlb${var.resource_suffix}"
   internal           = true
   load_balancer_type = "network"
@@ -258,7 +239,6 @@ resource "aws_lb" "apigw_nlb" {
 }
 
 resource "aws_lb_target_group" "apigw_metadata" {
-  count       = var.setup_alb && var.point_api_gateway_to_alb ? 1 : 0
   name        = "${var.resource_prefix}apigw-mdtg${var.resource_suffix}"
   port        = 80
   protocol    = "TCP"
@@ -276,13 +256,11 @@ resource "aws_lb_target_group" "apigw_metadata" {
 }
 
 resource "aws_lb_target_group_attachment" "apigw_metadata" {
-  count            = var.setup_alb && var.point_api_gateway_to_alb ? 1 : 0
   target_group_arn = aws_lb_target_group.apigw_metadata[0].arn
   target_id        = aws_lb.alb[0].arn
 }
 
 resource "aws_lb_target_group" "apigw_db_migrate" {
-  count       = var.setup_alb && var.point_api_gateway_to_alb ? 1 : 0
   name        = "${var.resource_prefix}apigw-dbtg${var.resource_suffix}"
   port        = 8082
   protocol    = "TCP"
@@ -301,13 +279,11 @@ resource "aws_lb_target_group" "apigw_db_migrate" {
 }
 
 resource "aws_lb_target_group_attachment" "apigw_db_migrate" {
-  count            = var.setup_alb && var.point_api_gateway_to_alb ? 1 : 0
   target_group_arn = aws_lb_target_group.apigw_db_migrate[0].arn
   target_id        = aws_lb.alb[0].arn
 }
 
 resource "aws_lb_listener" "apigw_metadata" {
-  count             = var.setup_alb && var.point_api_gateway_to_alb ? 1 : 0
   load_balancer_arn = aws_lb.apigw_nlb[0].arn
   port              = "80"
   protocol          = "TCP"
@@ -319,7 +295,6 @@ resource "aws_lb_listener" "apigw_metadata" {
 }
 
 resource "aws_lb_listener" "apigw_db_migrate" {
-  count             = var.setup_alb && var.point_api_gateway_to_alb ? 1 : 0
   load_balancer_arn = aws_lb.apigw_nlb[0].arn
   port              = "8082"
   protocol          = "TCP"

--- a/modules/metadata-service/ecs.tf
+++ b/modules/metadata-service/ecs.tf
@@ -68,8 +68,8 @@ EOF
 }
 
 locals {
-  alb_ports         = var.setup_alb ? [8080, 8082] : []
-  alb_target_groups = var.setup_alb ? [aws_lb_target_group.alb_main[0].arn, aws_lb_target_group.alb_db_migrate[0].arn] : []
+  alb_ports         = [8080, 8082]
+  alb_target_groups = [aws_lb_target_group.alb_main.arn, aws_lb_target_group.alb_db_migrate.arn]
 }
 
 resource "aws_ecs_service" "this" {
@@ -83,18 +83,6 @@ resource "aws_ecs_service" "this" {
     security_groups  = [aws_security_group.metadata_service_security_group.id]
     assign_public_ip = var.with_public_ip
     subnets          = [var.subnet1_id, var.subnet2_id]
-  }
-
-  load_balancer {
-    target_group_arn = aws_lb_target_group.this.arn
-    container_name   = "${var.resource_prefix}service${var.resource_suffix}"
-    container_port   = 8080
-  }
-
-  load_balancer {
-    target_group_arn = aws_lb_target_group.db_migrate.arn
-    container_name   = "${var.resource_prefix}service${var.resource_suffix}"
-    container_port   = 8082
   }
 
   dynamic "load_balancer" {

--- a/modules/metadata-service/lambda.tf
+++ b/modules/metadata-service/lambda.tf
@@ -126,7 +126,7 @@ resource "aws_lambda_function" "db_migrate_lambda" {
 
   environment {
     variables = {
-      MD_LB_ADDRESS = "http://${aws_lb.this.dns_name}:8082"
+      MD_LB_ADDRESS = "http://${aws_lb.alb.dns_name}:8082"
     }
   }
 

--- a/modules/metadata-service/outputs.tf
+++ b/modules/metadata-service/outputs.tf
@@ -1,5 +1,5 @@
 output "METAFLOW_SERVICE_INTERNAL_URL" {
-  value       = "http://${aws_lb.this.dns_name}/"
+  value       = "http://${aws_lb.alb.dns_name}/"
   description = "URL for Metadata Service (Accessible in VPC)"
 }
 
@@ -34,6 +34,6 @@ output "metadata_svc_ecs_task_role_arn" {
 }
 
 output "network_load_balancer_dns_name" {
-  value       = aws_lb.this.dns_name
+  value       = aws_lb.alb.dns_name
   description = "The DNS addressable name for the Network Load Balancer that accepts requests and forwards them to our Fargate MetaData service instance(s)"
 }

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -132,15 +132,3 @@ variable "with_public_ip" {
   default     = false
   description = "Enable private IP by default"
 }
-
-variable "setup_alb" {
-  type        = bool
-  default     = false
-  description = "Also setup an ALB for metadata service (will be default once we deprecate NLB completely)"
-}
-
-variable "point_api_gateway_to_alb" {
-  type        = bool
-  default     = false
-  description = "if setup_alb and point_api_gateway_to_alb is true, API gateway will point to ALB instead of NLB"
-}


### PR DESCRIPTION
This PR completely the deprecation of NLB and its migration to ALB towards DAT-106.
The `moved` blocks will be removed with a later PR after a subsequent apply.

Test plan
---
Check that terraform plan reports destroy of old NLB but no other changes.
